### PR TITLE
Replace workflow file icon with custom SVG

### DIFF
--- a/assets/workflow-file-icon.svg
+++ b/assets/workflow-file-icon.svg
@@ -1,0 +1,19 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Workflow file icon</title>
+  <desc id="desc">Blue square icon with chinese character Jing representing a workflow file.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4ad9ff" />
+      <stop offset="100%" stop-color="#0a6cff" />
+    </linearGradient>
+    <linearGradient id="highlight" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="200" height="200" rx="28" fill="url(#bg)" />
+  <path d="M36 20h54c20 0 36 16 36 36v4c0 20-16 36-36 36H36z" fill="#ffffff" opacity="0.2" />
+  <path d="M40 36h46c14 0 26 12 26 26v4c0 14-12 26-26 26H40z" fill="#ffffff" opacity="0.12" />
+  <path d="M28 120h64c28 0 48 20 48 48v12H28z" fill="url(#highlight)" opacity="0.45" />
+  <text x="136" y="142" font-size="112" font-family="'Noto Sans CJK SC','Microsoft YaHei','PingFang SC','Heiti SC','sans-serif'" font-weight="700" fill="#ffffff" text-anchor="middle">境</text>
+</svg>

--- a/js/workflow_api.js
+++ b/js/workflow_api.js
@@ -56,6 +56,13 @@ const WorkflowAPI = {
     }
 };
 
+function getIconHTML(itemType) {
+    if (itemType === 'directory') {
+        return '<i class="file-icon folder pi pi-folder" aria-hidden="true"></i>';
+    }
+    return '<span class="file-icon workflow" role="img" aria-label="工作流文件"></span>';
+}
+
 // 核心目录加载函数
 async function loadDirectory(path, skipViewModeApply = false) {
     
@@ -142,30 +149,30 @@ async function renderFileGrid(items) {
     
     fileGrid.innerHTML = sortedItems.map(item => {
         const isFolder = item.type === 'directory';
-        const iconClass = isFolder ? 'folder' : 'workflow';
-        const icon = isFolder ? 'pi-folder' : 'pi-file';
-        
-        const meta = isFolder 
-            ? `${item.workflow_count} 个工作流` 
+
+        const meta = isFolder
+            ? `${item.workflow_count} 个工作流`
             : `${formatDate(item.modified)}`;
-        
+
         // 检查是否在列表视图模式下
         const isListView = fileGrid.classList.contains('list-view');
-        
+
         // 为文件夹添加展开图标（仅在列表视图下）
-        const expandIcon = isFolder && isListView 
-            ? `<i class="folder-expand-icon pi pi-chevron-right" data-path="${item.path}" title="展开文件夹"></i>` 
+        const expandIcon = isFolder && isListView
+            ? `<i class="folder-expand-icon pi pi-chevron-right" data-path="${item.path}" title="展开文件夹"></i>`
             : '';
-        
+
+        const iconHtml = getIconHTML(item.type);
+
         return `
-            <div class="file-item" 
-                 data-path="${item.path}" 
+            <div class="file-item"
+                 data-path="${item.path}"
                  data-name="${item.name}"
                  data-type="${item.type}"
                  draggable="true">
                 ${expandIcon}
                 <div class="file-icon-container">
-                    <i class="file-icon ${iconClass} pi ${icon}" data-icon-path="${item.path}"></i>
+                    ${iconHtml}
                     ${!isFolder ? `<div class="preview-placeholder" data-preview-path="${item.path}" style="display: none;">
                         <div class="preview-loading" style="display: none;">
                             <div class="loading-spinner"></div>
@@ -205,18 +212,18 @@ async function renderFileGrid(items) {
                     
                     result.items.forEach((item, index) => {
                         const isFolder = item.type === 'directory';
-                        const iconClass = isFolder ? 'folder' : 'workflow';
-                        const icon = isFolder ? 'pi-folder' : 'pi-file';
-                        
-                        const meta = isFolder 
-                            ? `${item.workflow_count} 个工作流` 
+
+                        const meta = isFolder
+                            ? `${item.workflow_count} 个工作流`
                             : `${formatDate(item.modified)}`;
-                        
+
                         // 子文件夹也可以展开
-                        const expandIcon = isFolder 
-                            ? `<i class="folder-expand-icon pi pi-chevron-right" data-path="${item.path}" title="展开文件夹"></i>` 
+                        const expandIcon = isFolder
+                            ? `<i class="folder-expand-icon pi pi-chevron-right" data-path="${item.path}" title="展开文件夹"></i>`
                             : '';
-                        
+
+                        const iconHtml = getIconHTML(item.type);
+
                         const childItem = document.createElement('div');
                         childItem.className = 'file-item child-item';
                         childItem.dataset.path = item.path;
@@ -224,11 +231,11 @@ async function renderFileGrid(items) {
                         childItem.dataset.type = item.type;
                         childItem.dataset.parentPath = folderPath;
                         childItem.draggable = true;
-                        
+
                         childItem.innerHTML = `
                             ${expandIcon}
                             <div class="file-icon-container">
-                                <i class="file-icon ${iconClass} pi ${icon}"></i>
+                                ${iconHtml}
                             </div>
                             <div class="file-name">${item.name}</div>
                             <div class="file-meta">${meta}</div>
@@ -315,18 +322,18 @@ async function expandFolderContent(folderPath) {
             // 渲染子项目并直接插入到文件夹后面
             result.items.forEach((item, index) => {
                 const isFolder = item.type === 'directory';
-                const iconClass = isFolder ? 'folder' : 'workflow';
-                const icon = isFolder ? 'pi-folder' : 'pi-file';
-                
-                const meta = isFolder 
-                    ? `${item.workflow_count} 个工作流` 
+
+                const meta = isFolder
+                    ? `${item.workflow_count} 个工作流`
                     : `${formatDate(item.modified)}`;
-                
+
                 // 子文件夹也可以展开
-                const expandIcon = isFolder 
-                    ? `<i class="folder-expand-icon pi pi-chevron-right" data-path="${item.path}" title="展开文件夹"></i>` 
+                const expandIcon = isFolder
+                    ? `<i class="folder-expand-icon pi pi-chevron-right" data-path="${item.path}" title="展开文件夹"></i>`
                     : '';
-                
+
+                const iconHtml = getIconHTML(item.type);
+
                 const childItem = document.createElement('div');
                 childItem.className = 'file-item child-item';
                 childItem.dataset.path = item.path;
@@ -334,11 +341,11 @@ async function expandFolderContent(folderPath) {
                 childItem.dataset.type = item.type;
                 childItem.dataset.parentPath = folderPath;
                 childItem.draggable = true;
-                
+
                 childItem.innerHTML = `
                     ${expandIcon}
                     <div class="file-icon-container">
-                        <i class="file-icon ${iconClass} pi ${icon}"></i>
+                        ${iconHtml}
                     </div>
                     <div class="file-name">${item.name}</div>
                     <div class="file-meta">${meta}</div>

--- a/js/workflow_operations.js
+++ b/js/workflow_operations.js
@@ -2,15 +2,16 @@
 // 文件操作和拖拽功能
 
 import { api } from "../../../scripts/api.js";
-import { 
-    PLUGIN_NAME, 
-    managerState, 
-    formatDate, 
+import {
+    PLUGIN_NAME,
+    managerState,
+    formatDate,
     sortItems,
-    showToast, 
+    showToast,
     showLoading,
     clearSelection,
-    addSelection
+    addSelection,
+    WORKFLOW_FILE_ICON_PATH
 } from './workflow_state.js';
 
 import { createDragImage, isSubDirectory } from './workflow_styles.js';
@@ -542,8 +543,10 @@ function showPropertiesDialog(path) {
                 border-bottom: none;
             }
             
-            .properties-list-item i {
+            .properties-list-item i,
+            .properties-list-item .workflow-icon-inline {
                 color: var(--descrip-text, #999);
+                flex-shrink: 0;
             }
             
             .properties-list-item span {
@@ -597,10 +600,12 @@ function showMultiplePropertiesDialog(paths) {
                         const item = document.querySelector(`[data-path="${path}"]`);
                         const name = item?.dataset.name || path;
                         const type = item?.dataset.type || 'workflow';
-                        const icon = type === 'directory' ? 'pi-folder' : 'pi-file';
+                        const iconHtml = type === 'directory'
+                            ? '<i class="pi pi-folder" aria-hidden="true"></i>'
+                            : `<span class="workflow-icon-inline small" aria-hidden="true" style="background-image: url('${WORKFLOW_FILE_ICON_PATH}');"></span>`;
                         return `
                             <div class="properties-list-item">
-                                <i class="pi ${icon}"></i>
+                                ${iconHtml}
                                 <span>${name}</span>
                             </div>
                         `;
@@ -681,8 +686,17 @@ function handleDragStart(e) {
             gap: 8px;
             z-index: 1000;
         `;
-        dragImage.innerHTML = `<i class="pi pi-file" style="color: #28a745;"></i>${fileItem.dataset.name}`;
-        
+        dragImage.innerHTML = '';
+        const dragIcon = document.createElement('span');
+        dragIcon.className = 'workflow-icon-inline';
+        dragIcon.style.backgroundImage = `url('${WORKFLOW_FILE_ICON_PATH}')`;
+        dragIcon.setAttribute('aria-hidden', 'true');
+        dragImage.appendChild(dragIcon);
+
+        const dragLabel = document.createElement('span');
+        dragLabel.textContent = fileItem.dataset.name;
+        dragImage.appendChild(dragLabel);
+
         document.body.appendChild(dragImage);
         e.dataTransfer.setDragImage(dragImage, 20, 20);
         

--- a/js/workflow_state.js
+++ b/js/workflow_state.js
@@ -2,6 +2,8 @@
 // 状态管理和工具函数
 
 const PLUGIN_NAME = "WorkflowManager";
+// 自定义工作流文件图标路径
+const WORKFLOW_FILE_ICON_PATH = "extensions/ComfyUI-WorkflowManager/assets/workflow-file-icon.svg";
 
 // 管理器状态
 const managerState = {
@@ -482,5 +484,6 @@ export {
     preloadNearbyPreviews,
     clearImageCache,
     getPreviewPath,
-    testPreviewAPI
-}; 
+    testPreviewAPI,
+    WORKFLOW_FILE_ICON_PATH
+};

--- a/js/workflow_styles.js
+++ b/js/workflow_styles.js
@@ -1,6 +1,8 @@
 // js/workflow_styles.js
 // 样式定义和UI组件
 
+import { WORKFLOW_FILE_ICON_PATH } from './workflow_state.js';
+
 // 添加管理器样式
 function addManagerStyles() {
     if (document.querySelector('#workflow-manager-styles')) return;
@@ -197,17 +199,29 @@ function addManagerStyles() {
         }
         
         .file-icon {
-            font-size: 48px;
             margin-bottom: 6px;
             color: #007acc;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 48px;
+            flex-shrink: 0;
         }
-        
+
         .file-icon.folder {
             color: #ffa500;
         }
-        
+
         .file-icon.workflow {
-            color: #28a745;
+            width: 48px;
+            height: 48px;
+            margin-bottom: 6px;
+            background-image: url('${WORKFLOW_FILE_ICON_PATH}');
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: contain;
+            font-size: 0;
+            color: transparent;
         }
         
         /* 预览图相关样式 */
@@ -246,6 +260,11 @@ function addManagerStyles() {
             font-size: 20px;
             margin-bottom: 0;
             margin-right: 12px;
+        }
+
+        .file-grid.list-view .file-icon.workflow {
+            width: 24px;
+            height: 24px;
         }
         
         .preview-loading {
@@ -309,6 +328,24 @@ function addManagerStyles() {
             object-position: center;
             border-radius: 4px;
             transform-origin: center;
+        }
+
+        .workflow-icon-inline {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            margin-right: 8px;
+            background-image: url('${WORKFLOW_FILE_ICON_PATH}');
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: contain;
+            vertical-align: middle;
+        }
+
+        .workflow-icon-inline.small {
+            width: 16px;
+            height: 16px;
+            margin-right: 6px;
         }
         
         .file-name {


### PR DESCRIPTION
## Summary
- add a dedicated SVG icon asset for workflow files and expose its path to the frontend modules
- swap workflow file markup to use the new graphic across grid/list rendering, child folders, properties dialog, and drag previews
- adjust shared styles so workflow items and inline icons use the SVG while keeping folder icons unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca9dbed6688328a119a068a62ffa4f